### PR TITLE
chore: add init DB script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cp .env.example .env
 ### Subir os container
 
 ```bash
-docker-compose up
+docker-compose up --build
 ```
 
 ### Entrar no pasta /frontend

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,4 +14,4 @@ RUN npm run build
 
 EXPOSE 8080
 
-CMD ["npm", "run", "start:prod"]
+CMD ["sh", "-c", "npm run db:migrate && npm run start:prod"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,9 @@
     "start": "nest start",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest"
+    "test": "jest",
+    "db:migrate": "prisma migrate deploy",
+    "db:generate": "prisma generate"
   },
   "dependencies": {
     "@nestjs/common": "11.1.3",

--- a/compose.yml
+++ b/compose.yml
@@ -12,6 +12,7 @@ services:
       - "5436:5432"
     volumes:
       - db_data:/var/lib/postgresql/data
+      - ./init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
@@ -45,7 +46,7 @@ services:
         condition: service_healthy
     ports:
       - "8080:8080"
-    command: npm run start:prod
+    command: sh -c "npm run db:migrate && npm run start:prod"
     working_dir: /app
     env_file:
       - ./backend/.env

--- a/init-db.sh
+++ b/init-db.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+# Função para criar o banco se não existir
+create_database() {
+    local database=$1
+    echo "Verificando se o banco '$database' existe..."
+
+    # Aguarda o PostgreSQL estar pronto
+    until pg_isready -U postgres; do
+        echo "Aguardando PostgreSQL..."
+        sleep 2
+    done
+
+    # Verifica se o banco existe
+    if psql -U postgres -lqt | cut -d \| -f 1 | grep -qw "$database"; then
+        echo "Banco '$database' já existe."
+    else
+        echo "Criando banco '$database'..."
+        createdb -U postgres "$database"
+        echo "Banco '$database' criado com sucesso!"
+    fi
+}
+
+if [ -n "$POSTGRES_DB" ]; then
+    create_database "$POSTGRES_DB"
+fi
+
+echo "Inicialização do banco concluída!"


### PR DESCRIPTION
Este PR adiciona um script de inicialização para o banco de dados, facilitando a criação de um novo banco com estrutura pronta.

### Contexto:

Atualmente, o nome padrão do banco é `database`. 
Com este script, é possível trocar o nome do banco (por exemplo, para `batata`) e, ao executar `docker-compose up`, o banco já será criado e inicializado automaticamente.

Isso simplifica a configuração do ambiente local e a adaptação a diferentes nomes de banco durante o desenvolvimento ou testes.